### PR TITLE
Added read from absolute path functionality for excel workbook path.

### DIFF
--- a/seclo.go
+++ b/seclo.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	azkv "secret-loader/azure_keyvault"
 	"strings"
 
@@ -26,7 +27,11 @@ func main() {
 
 	flag.Parse()
 
-	f, err := excelize.OpenFile(cwd + "/" + *file_path)
+	if path.IsAbs(*file_path) == true {
+		f, err := excelize.OpenFile(*file_path)
+	} else {
+		f, err := excelize.OpenFile(cwd + "/" + *file_path)
+	}
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)


### PR DESCRIPTION
Added read from absolute path functionality for excel workbook path. This will take decision on runtime basis based on the file argument flag provided. If file path is provided as absolute path, program will pick up that path, otherwise if the provided path is not absolute, program will compose relative path appending CWD from where the executable is being run to the file argument flag provided.